### PR TITLE
Refactor AI model config to central file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,8 @@ A Next.js application that helps users create personalized learning plans using 
    CEREBRAS_API_KEY=your_cerebras_api_key
    # Optional: override the base URL if you are using a private deployment
    # CEREBRAS_BASE_URL=https://api.cerebras.ai/v1
-
-   # Optional: override the model used for different flows
-   # AI_MODEL_ID=gpt-5-mini
-   # AI_MODEL_CHAT=gpt-5-mini
-   # AI_MODEL_PLAN=gpt-5-mini
-   # AI_MODEL_COURSE=gpt-5-mini
    ```
-   - For Cerebras, set `AI_MODEL_ID` (or the per-use-case variables) to a model offered by the service, for example `llama3.1-8b-instruct`.
+   - Modify `lib/ai/config.ts` to adjust the default models for each provider/use case. For example, `gpt-oss-120b` for Cerebras chat or `gpt-5-mini` for OpenAI.
 
 3. **Set up Supabase (required for persistence)**:
    Add these variables to `.env.local`:

--- a/lib/ai/config.ts
+++ b/lib/ai/config.ts
@@ -1,0 +1,20 @@
+export const AI_MODEL_USE_CASES = ['chat', 'plan', 'course'] as const;
+
+export type AIModelUseCase = (typeof AI_MODEL_USE_CASES)[number];
+
+export type AIModelConfig = Record<AIModelUseCase, string>;
+
+export const AI_MODEL_CONFIG = {
+  openai: {
+    chat: 'gpt-5-mini',
+    plan: 'gpt-5-mini',
+    course: 'gpt-5-mini',
+  },
+  cerebras: {
+    chat: 'gpt-oss-120b',
+    plan: 'gpt-oss-120b',
+    course: 'gpt-oss-120b',
+  },
+} as const satisfies Record<string, AIModelConfig>;
+
+export type AIProviderName = keyof typeof AI_MODEL_CONFIG;

--- a/lib/ai/provider.ts
+++ b/lib/ai/provider.ts
@@ -1,11 +1,13 @@
 import { createOpenAI, type OpenAIProvider } from '@ai-sdk/openai';
+import {
+  AI_MODEL_CONFIG,
+  type AIModelUseCase,
+  type AIProviderName,
+} from '@/lib/ai/config';
 
 const DEFAULT_CEREBRAS_BASE_URL = 'https://api.cerebras.ai/v1';
 
-const SUPPORTED_PROVIDERS = ['openai', 'cerebras'] as const;
-
-export type AIProviderName = (typeof SUPPORTED_PROVIDERS)[number];
-export type AIModelUseCase = 'chat' | 'plan' | 'course';
+const SUPPORTED_PROVIDERS = Object.keys(AI_MODEL_CONFIG) as AIProviderName[];
 
 function resolveProviderName(): AIProviderName {
   const raw = process.env.AI_PROVIDER?.trim().toLowerCase() ?? 'openai';
@@ -47,24 +49,10 @@ const provider: OpenAIProvider =
         ),
       });
 
-const defaultModel =
-  process.env.AI_MODEL_ID?.trim() ||
-  (providerName === 'openai' ? 'gpt-5-mini' : 'llama3.1-8b-instruct');
-
-const modelMap: Record<AIModelUseCase, string> = {
-  chat: process.env.AI_MODEL_CHAT?.trim() || defaultModel,
-  plan:
-    process.env.AI_MODEL_PLAN?.trim() ||
-    process.env.AI_MODEL_CHAT?.trim() ||
-    defaultModel,
-  course:
-    process.env.AI_MODEL_COURSE?.trim() ||
-    process.env.AI_MODEL_CHAT?.trim() ||
-    defaultModel,
-};
+const modelConfig = AI_MODEL_CONFIG[providerName];
 
 export function getModelId(useCase: AIModelUseCase = 'chat'): string {
-  return modelMap[useCase];
+  return modelConfig[useCase];
 }
 
 export function getModel(useCase: AIModelUseCase = 'chat') {


### PR DESCRIPTION
Moved AI model configuration to lib/ai/config.ts for easier management of default models per provider and use case. Updated provider logic to use centralized config and adjusted README instructions accordingly.