### PR TITLE
feat: add course engagement blocks and responses functionality

### DIFF
--- a/app/api/course-versions/[versionId]/engagement-blocks/route.ts
+++ b/app/api/course-versions/[versionId]/engagement-blocks/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import {
+  getCourseVersionForUser,
+  listCourseEngagementBlocks,
+} from '@/lib/db/operations';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ versionId: string }> },
+) {
+  const { versionId } = await params;
+
+  if (!versionId || versionId.trim().length === 0) {
+    return NextResponse.json(
+      { error: 'courseVersionId is required' },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  const record = await getCourseVersionForUser({
+    courseVersionId: versionId,
+    userId: user.id,
+  });
+
+  if (!record) {
+    return NextResponse.json({ error: 'Course version not found' }, { status: 404 });
+  }
+
+  const blocks = await listCourseEngagementBlocks({
+    courseVersionId: versionId,
+  });
+
+  return NextResponse.json({
+    courseId: record.course.id,
+    courseVersionId: versionId,
+    blocks: blocks.map((block) => ({
+      id: block.blockId,
+      type: block.blockType,
+      order: block.blockOrder,
+      revision: block.blockRevision,
+      contentHash: block.contentHash,
+      submoduleId: block.submoduleId,
+      payload: block.payload,
+    })),
+  });
+}

--- a/app/api/course-versions/[versionId]/engagement-responses/[blockId]/route.ts
+++ b/app/api/course-versions/[versionId]/engagement-responses/[blockId]/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import {
+  deleteCourseEngagementResponse,
+  getCourseVersionForUser,
+} from '@/lib/db/operations';
+
+export async function DELETE(
+  _req: Request,
+  {
+    params,
+  }: { params: Promise<{ versionId: string; blockId: string }> },
+) {
+  const { versionId, blockId } = await params;
+
+  if (!versionId || versionId.trim().length === 0) {
+    return NextResponse.json(
+      { error: 'courseVersionId is required' },
+      { status: 400 },
+    );
+  }
+
+  if (!blockId || blockId.trim().length === 0) {
+    return NextResponse.json(
+      { error: 'blockId is required' },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  const record = await getCourseVersionForUser({
+    courseVersionId: versionId,
+    userId: user.id,
+  });
+
+  if (!record) {
+    return NextResponse.json({ error: 'Course version not found' }, { status: 404 });
+  }
+
+  await deleteCourseEngagementResponse({
+    userId: user.id,
+    courseVersionId: versionId,
+    blockId,
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/course-versions/[versionId]/engagement-responses/route.ts
+++ b/app/api/course-versions/[versionId]/engagement-responses/route.ts
@@ -1,0 +1,180 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import {
+  getCourseVersionForUser,
+  listCourseEngagementResponses,
+  listCourseEngagementBlocks,
+  getCourseEngagementBlock,
+  upsertCourseEngagementResponse,
+} from '@/lib/db/operations';
+
+const UpsertEngagementResponseSchema = z.object({
+  blockId: z.string().min(1),
+  blockType: z.enum(['quiz', 'reflection']),
+  submoduleId: z.string().min(1),
+  contentHash: z.string().min(1).optional(),
+  response: z.unknown(),
+  score: z.number().int().optional(),
+  isCorrect: z.boolean().optional(),
+});
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ versionId: string }> },
+) {
+  const { versionId } = await params;
+
+  if (!versionId || versionId.trim().length === 0) {
+    return NextResponse.json(
+      { error: 'courseVersionId is required' },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  const record = await getCourseVersionForUser({
+    courseVersionId: versionId,
+    userId: user.id,
+  });
+
+  if (!record) {
+    return NextResponse.json({ error: 'Course version not found' }, { status: 404 });
+  }
+
+  const [blocks, responses] = await Promise.all([
+    listCourseEngagementBlocks({ courseVersionId: versionId }),
+    listCourseEngagementResponses({ courseVersionId: versionId, userId: user.id }),
+  ]);
+
+  const blockHash = new Map(
+    blocks.map((block) => [block.blockId, block] as const),
+  );
+
+  return NextResponse.json({
+    courseId: record.course.id,
+    courseVersionId: versionId,
+    responses: responses.map((response) => {
+      const block = blockHash.get(response.blockId);
+      const isStale =
+        Boolean(block) && block!.contentHash !== response.contentHash;
+      return {
+        blockId: response.blockId,
+        blockType: response.blockType,
+        submoduleId: response.submoduleId,
+        blockRevision: response.blockRevision,
+        contentHash: response.contentHash,
+        response: response.response,
+        score: response.score,
+        isCorrect: response.isCorrect,
+        stale: isStale,
+        createdAt: response.createdAt,
+        updatedAt: response.updatedAt,
+      };
+    }),
+  });
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ versionId: string }> },
+) {
+  const { versionId } = await params;
+
+  if (!versionId || versionId.trim().length === 0) {
+    return NextResponse.json(
+      { error: 'courseVersionId is required' },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: 'Not authenticated' }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const parseResult = UpsertEngagementResponseSchema.safeParse(body);
+
+  if (!parseResult.success) {
+    return NextResponse.json(
+      {
+        error: 'Invalid request',
+        details: parseResult.error.flatten(),
+      },
+      { status: 400 },
+    );
+  }
+
+  const payload = parseResult.data;
+
+  const record = await getCourseVersionForUser({
+    courseVersionId: versionId,
+    userId: user.id,
+  });
+
+  if (!record) {
+    return NextResponse.json({ error: 'Course version not found' }, { status: 404 });
+  }
+
+  const block = await getCourseEngagementBlock({
+    courseVersionId: versionId,
+    blockId: payload.blockId,
+  });
+
+  if (!block) {
+    return NextResponse.json(
+      { error: 'Engagement block not found' },
+      { status: 404 },
+    );
+  }
+
+  if (
+    payload.contentHash &&
+    payload.contentHash.trim().length > 0 &&
+    payload.contentHash !== block.contentHash
+  ) {
+    return NextResponse.json(
+      {
+        error: 'Engagement block has been updated. Please refresh and try again.',
+        code: 'stale-block',
+        expectedHash: block.contentHash,
+      },
+      { status: 409 },
+    );
+  }
+
+  await upsertCourseEngagementResponse({
+    userId: user.id,
+    courseId: record.course.id,
+    courseVersionId: versionId,
+    blockId: block.blockId,
+    blockType: block.blockType,
+    submoduleId: block.submoduleId,
+    blockRevision: block.blockRevision,
+    contentHash: block.contentHash,
+    response: payload.response,
+    score: payload.score ?? null,
+    isCorrect: payload.isCorrect ?? null,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    courseId: record.course.id,
+    courseVersionId: versionId,
+    blockId: block.blockId,
+    stale: false,
+  });
+}

--- a/components/course/markdown-content.tsx
+++ b/components/course/markdown-content.tsx
@@ -2,7 +2,6 @@
 
 import {
   type ComponentPropsWithoutRef,
-  type ReactElement,
   type ReactNode,
   Fragment,
   isValidElement,

--- a/drizzle/migrations/0005_swift_alex_wilder.sql
+++ b/drizzle/migrations/0005_swift_alex_wilder.sql
@@ -1,0 +1,38 @@
+CREATE TABLE "course_engagement_blocks" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"course_version_id" uuid NOT NULL,
+	"submodule_id" text NOT NULL,
+	"block_id" text NOT NULL,
+	"block_type" text NOT NULL,
+	"block_order" integer NOT NULL,
+	"block_revision" integer NOT NULL,
+	"content_hash" text NOT NULL,
+	"payload" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "course_engagement_responses" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"course_id" uuid NOT NULL,
+	"course_version_id" uuid NOT NULL,
+	"submodule_id" text NOT NULL,
+	"block_id" text NOT NULL,
+	"block_type" text NOT NULL,
+	"block_revision" integer NOT NULL,
+	"content_hash" text NOT NULL,
+	"response" jsonb NOT NULL,
+	"score" integer,
+	"is_correct" boolean,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "course_engagement_blocks" ADD CONSTRAINT "course_engagement_blocks_course_version_id_course_versions_id_fk" FOREIGN KEY ("course_version_id") REFERENCES "public"."course_versions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "course_engagement_responses" ADD CONSTRAINT "course_engagement_responses_course_id_courses_id_fk" FOREIGN KEY ("course_id") REFERENCES "public"."courses"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "course_engagement_responses" ADD CONSTRAINT "course_engagement_responses_course_version_id_course_versions_id_fk" FOREIGN KEY ("course_version_id") REFERENCES "public"."course_versions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "course_engagement_blocks_version_block_idx" ON "course_engagement_blocks" USING btree ("course_version_id","block_id");--> statement-breakpoint
+CREATE INDEX "course_engagement_blocks_order_idx" ON "course_engagement_blocks" USING btree ("course_version_id","block_order");--> statement-breakpoint
+CREATE UNIQUE INDEX "course_engagement_responses_unique" ON "course_engagement_responses" USING btree ("user_id","course_version_id","block_id");--> statement-breakpoint
+CREATE INDEX "course_engagement_responses_version_block_idx" ON "course_engagement_responses" USING btree ("course_version_id","block_id");

--- a/drizzle/migrations/meta/0005_snapshot.json
+++ b/drizzle/migrations/meta/0005_snapshot.json
@@ -1,0 +1,712 @@
+{
+  "id": "2a657cde-733c-4cfb-bf58-7dfa721172ca",
+  "prevId": "1d273c2f-334b-479f-9984-ddb7d18abf4f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_sessions": {
+      "name": "chat_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_engagement_blocks": {
+      "name": "course_engagement_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_version_id": {
+          "name": "course_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submodule_id": {
+          "name": "submodule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_type": {
+          "name": "block_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_order": {
+          "name": "block_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_revision": {
+          "name": "block_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "course_engagement_blocks_version_block_idx": {
+          "name": "course_engagement_blocks_version_block_idx",
+          "columns": [
+            {
+              "expression": "course_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "course_engagement_blocks_order_idx": {
+          "name": "course_engagement_blocks_order_idx",
+          "columns": [
+            {
+              "expression": "course_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "block_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_engagement_blocks_course_version_id_course_versions_id_fk": {
+          "name": "course_engagement_blocks_course_version_id_course_versions_id_fk",
+          "tableFrom": "course_engagement_blocks",
+          "tableTo": "course_versions",
+          "columnsFrom": [
+            "course_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_engagement_responses": {
+      "name": "course_engagement_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course_version_id": {
+          "name": "course_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submodule_id": {
+          "name": "submodule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_type": {
+          "name": "block_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_revision": {
+          "name": "block_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_correct": {
+          "name": "is_correct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "course_engagement_responses_unique": {
+          "name": "course_engagement_responses_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "course_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "course_engagement_responses_version_block_idx": {
+          "name": "course_engagement_responses_version_block_idx",
+          "columns": [
+            {
+              "expression": "course_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "course_engagement_responses_course_id_courses_id_fk": {
+          "name": "course_engagement_responses_course_id_courses_id_fk",
+          "tableFrom": "course_engagement_responses",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_engagement_responses_course_version_id_course_versions_id_fk": {
+          "name": "course_engagement_responses_course_version_id_course_versions_id_fk",
+          "tableFrom": "course_engagement_responses",
+          "tableTo": "course_versions",
+          "columnsFrom": [
+            "course_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_generation_jobs": {
+      "name": "course_generation_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assistant_message_id": {
+          "name": "assistant_message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queue_job_id": {
+          "name": "queue_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_by": {
+          "name": "processing_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_summary": {
+          "name": "result_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_course_id": {
+          "name": "result_course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_course_version_id": {
+          "name": "result_course_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_course_structured": {
+          "name": "result_course_structured",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_generation_snapshots": {
+      "name": "course_generation_snapshots",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "structured_partial": {
+          "name": "structured_partial",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_progress": {
+          "name": "module_progress",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_generation_snapshots_job_id_course_generation_jobs_id_fk": {
+          "name": "course_generation_snapshots_job_id_course_generation_jobs_id_fk",
+          "tableFrom": "course_generation_snapshots",
+          "tableTo": "course_generation_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_versions": {
+      "name": "course_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structured": {
+          "name": "structured",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.courses": {
+      "name": "courses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_version_id": {
+          "name": "active_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1760650954641,
       "tag": "0004_parched_wildside",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1760754431772,
+      "tag": "0005_swift_alex_wilder",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/ai/tool-output.ts
+++ b/lib/ai/tool-output.ts
@@ -32,6 +32,14 @@ export type CourseModuleProgress = {
   }[];
 };
 
+export type CourseEngagementBlockSummary = {
+  blockId: string;
+  blockType: string;
+  blockRevision: number;
+  contentHash: string;
+  submoduleId: string;
+};
+
 export type CourseToolOutput = {
   course?: string;
   courseStructured?: CourseWithIds;
@@ -41,6 +49,9 @@ export type CourseToolOutput = {
   startedAt?: number;
   durationMs?: number;
   moduleProgress?: CourseModuleProgress;
+  courseId?: string;
+  courseVersionId?: string;
+  engagementBlocks?: CourseEngagementBlockSummary[];
 };
 
 export type ToolErrorOutput = {

--- a/lib/ai/tools/types.ts
+++ b/lib/ai/tools/types.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
 
+const EngagementMetadataSchema = z.object({
+  id: z.string().min(1).optional(),
+  revision: z.number().int().positive().optional(),
+  contentHash: z.string().min(1).optional(),
+});
+
 export const QuizEngagementBlockSchema = z.object({
   type: z.literal("quiz"),
   prompt: z.string().min(1),
@@ -7,7 +13,7 @@ export const QuizEngagementBlockSchema = z.object({
   correctOptionIndex: z.number().int().nonnegative(),
   rationale: z.string().optional(),
   difficulty: z.enum(["beginner", "intermediate", "advanced"]).optional(),
-});
+}).merge(EngagementMetadataSchema);
 
 export type QuizEngagementBlock = z.infer<typeof QuizEngagementBlockSchema>;
 
@@ -16,7 +22,7 @@ export const ReflectionEngagementBlockSchema = z.object({
   prompt: z.string().min(1),
   guidance: z.string().optional(),
   expectedDurationMinutes: z.number().int().positive().optional(),
-});
+}).merge(EngagementMetadataSchema);
 
 export type ReflectionEngagementBlock = z.infer<
   typeof ReflectionEngagementBlockSchema
@@ -31,3 +37,8 @@ export type EngagementBlock = z.infer<typeof EngagementBlockSchema>;
 
 export const EngagementBlockArraySchema = z.array(EngagementBlockSchema);
 
+export type EngagementBlockWithMetadata = EngagementBlock & {
+  id?: string;
+  revision?: number;
+  contentHash?: string;
+};


### PR DESCRIPTION
- Implemented new database tables for course engagement blocks and responses.
- Added operations for creating, listing, updating, and deleting engagement blocks and responses.
- Enhanced course generation process to include engagement blocks.
- Created API routes for managing engagement blocks and responses.
- Updated database schema and migrations to support new features.